### PR TITLE
Fix spectral conversion to DB

### DIFF
--- a/nice/collection.py
+++ b/nice/collection.py
@@ -193,7 +193,7 @@ def read_markers(fname):
     epochs = None
     if 'nice/markers/order' in contents:
         marker_order = read_hdf5(fname, title='nice/markers/order',
-                                  slash='replace')
+                                 slash='replace')
     else:
         marker_order = [k for k in contents if 'nice/marker/' in k]
 

--- a/nice/markers/base.py
+++ b/nice/markers/base.py
@@ -155,7 +155,8 @@ class BaseMarker(BaseContainer):
                                 .swapaxes(0, this_axis))
         return data
 
-    def _prepare_reduction(self, reduction_func, target, picks):
+    def _prepare_reduction(self, reduction_func, target, picks,
+                           return_axis=False):
         data = self._prepare_data(picks, target)
         _axis_map = self._axis_map
         funcs = list()
@@ -188,7 +189,11 @@ class BaseMarker(BaseContainer):
         logger.info('Reduction order for {}: {}'.format(
             self._get_title(), permutation_axes))
         data = np.transpose(data, permutation_list)
-        return data, funcs
+        if return_axis is False:
+            out = data, funcs
+        else:
+            out = data, funcs, permutation_axes
+        return out
 
 
 class BaseTimeLocked(BaseMarker):

--- a/nice/markers/spectral.py
+++ b/nice/markers/spectral.py
@@ -205,9 +205,20 @@ class PowerSpectralDensity(BasePowerSpectralDensity):
         else:
             this_psds = self.estimator.data_[
                 ..., start:end][:, ch_picks][epochs_picks]
-        if self.dB is True and self.normalize is False:
-            this_psds = 10 * np.log10(this_psds)
         return this_psds
+
+    def _reduce_to(self, reduction_func, target, picks):
+        if not hasattr(self, 'data_'):
+            raise ValueError('You did not fit me. Do it again after fitting '
+                             'some data!')
+        out, funcs, axis = self._prepare_reduction(
+            reduction_func, target, picks, return_axis=True)
+        for func, ax in zip(funcs, axis):
+            out = func(out, axis=0)
+            if (self.dB is True and self.normalize is False and
+                    ax == 'frequency'):
+                out = 10 * np.log10(out)
+        return out
 
     @classmethod
     def _read(cls, fname, estimators=None, comment='default'):

--- a/nice/markers/tests/test_markers.py
+++ b/nice/markers/tests/test_markers.py
@@ -164,6 +164,18 @@ def test_spectral():
     _base_io_test(psd, epochs,
                   functools.partial(read_psd,
                                     estimators={'default': estimator}))
+
+    reduction_func = [
+        {'axis': 'frequency', 'function': np.sum},
+        {'axis': 'channels', 'function': np.mean},
+        {'axis': 'epochs', 'function': np.mean}]
+    out = psd._prepare_data(picks=None, target='scalar')
+    out = np.sum(out, axis=-1)
+    out = 10 * np.log10(out)
+    out = np.mean(out, axis=-1)
+    out = np.mean(out, axis=-1)
+    scalar = psd.reduce_to_scalar(reduction_func)
+    assert_equal(scalar, out)
     # TODO: Fix this test
     # _base_reduction_test(psd, epochs)
     # _base_compression_test(psd, epochs)


### PR DESCRIPTION
There is a bug when reducing the PSD and applying the DB conversion.

We currently compute the welch method, convert everything to DB by doing `10 * np.log10(data)` and then reducing.

If we apply any operation on the frequency axis, like the `sum` function to compute bands, we need to do the DB conversion AFTER the reduction.

This PR fixes that.