### PR TITLE
Updated nice code to be compatible with the MNE 0.24.1 stable version

### DIFF
--- a/nice/markers/base.py
+++ b/nice/markers/base.py
@@ -25,7 +25,7 @@ from ..utils import write_hdf5_mne_epochs, info_to_dict
 import numpy as np
 
 from mne.utils import logger
-from mne.epochs import _compare_epochs_infos
+from mne.io.meas_info import _ensure_infos_match # mne version 0.24.1
 from mne.io.meas_info import Info
 from mne.externals.h5io import write_hdf5, read_hdf5
 import h5py
@@ -317,7 +317,7 @@ def _read_container(klass, fname, comment='default'):
 
 
 def _check_epochs_consistency(info1, info2, shape1, shape2):
-    _compare_epochs_infos(info1, info2, 2)
+    _ensure_infos_match(info1, info2, 'epochs[2]')
     np.testing.assert_array_equal(shape1, shape2)
 
 


### PR DESCRIPTION
The MNE internal helper _compare_epochs_infos is deprecated in the 0.24.1 last stable version of the library. This function was redefined as _ensure_infos_match.